### PR TITLE
Fix canonical link injection and structured data URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
       "@context": "https://schema.org",
       "@type": "Organization",
       "name": "Protolab",
-      "url": "",
+      "url": "https://protolab.tech",
       "logo": "/assets/images/logo.svg",
       "description": "Professional 3D printing, laser cutting, CNC engraving, and creative design support services.",
       "sameAs": [
@@ -162,7 +162,10 @@
   
   <!-- Canonical URL with JavaScript for custom domain support -->
   <script>
-    document.head.innerHTML += '<link rel="canonical" href="' + window.location.protocol + '//' + window.location.host + window.location.pathname + '">';
+    const canonicalLink = document.createElement('link');
+    canonicalLink.rel = 'canonical';
+    canonicalLink.href = window.location.protocol + '//' + window.location.host + window.location.pathname;
+    document.head.appendChild(canonicalLink);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add missing `url` field to structured data block
- append canonical link using DOM API instead of innerHTML

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68944b447e4c8331958077020d890e08