### PR TITLE
Fix favicon path for Service Appointments page

### DIFF
--- a/Service Appointments/index.html
+++ b/Service Appointments/index.html
@@ -23,7 +23,7 @@
     <meta name="twitter:image" content="/images/hero.jpg" />
     
     <title>Service Appointments - Protolab</title>
-    <link rel="icon" type="image/svg+xml" href="/Service Appointments/images/logo.svg">
+    <link rel="icon" type="image/svg+xml" href="/Service%20Appointments/images/logo.svg">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
     
     <!-- Security headers -->


### PR DESCRIPTION
## Summary
- encode space in Service Appointments favicon path so browser loads logo

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python3 -m http.server 8000 &` / `curl -I http://localhost:8000/Service%20Appointments/images/logo.svg`


------
https://chatgpt.com/codex/tasks/task_e_68944e3151748331abbc1e9ef8563275