### PR TITLE
feat: add analytics with cookie consent

### DIFF
--- a/Chosko/about.html
+++ b/Chosko/about.html
@@ -76,6 +76,7 @@
         </div>
     </footer>
 
+    <script src="../assets/js/monitoring.js" defer></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             const menuButton = document.querySelector('.menu-button');

--- a/Chosko/index.html
+++ b/Chosko/index.html
@@ -105,6 +105,7 @@
         </div>
     </footer>
 
+    <script src="../assets/js/monitoring.js" defer></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             const menuButton = document.querySelector('.menu-button');

--- a/Chosko/policy.html
+++ b/Chosko/policy.html
@@ -104,6 +104,7 @@
         </div>
     </footer>
 
+    <script src="../assets/js/monitoring.js" defer></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             const menuButton = document.querySelector('.menu-button');

--- a/Kaolin/index.html
+++ b/Kaolin/index.html
@@ -230,6 +230,7 @@
       </div>
     </div>
   </footer>
+  <script src="../assets/js/monitoring.js" defer></script>
 
   <!-- Structured Data -->
   <script type="application/ld+json">

--- a/Service Appointments/index.html
+++ b/Service Appointments/index.html
@@ -384,7 +384,8 @@
             </form>
         </section>
     </main>
-    
+    <script src="../assets/js/monitoring.js" defer></script>
+
     <!-- Structured Data -->
     <script type="application/ld+json">
         {

--- a/assets/js/monitoring.js
+++ b/assets/js/monitoring.js
@@ -1,0 +1,54 @@
+(function() {
+  // Load cookie consent stylesheet
+  var ccCss = document.createElement('link');
+  ccCss.rel = 'stylesheet';
+  ccCss.href = 'https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.css';
+  document.head.appendChild(ccCss);
+
+  // Load cookie consent script
+  var ccScript = document.createElement('script');
+  ccScript.src = 'https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js';
+  ccScript.onload = initCookieConsent;
+  document.head.appendChild(ccScript);
+
+  function initCookieConsent() {
+    window.cookieconsent.initialise({
+      palette: {
+        popup: { background: '#000' },
+        button: { background: '#f1d600' }
+      },
+      type: 'opt-in',
+      content: {
+        message: 'This website uses cookies for analytics.',
+        dismiss: 'Allow',
+        deny: 'Decline',
+        link: 'Learn more',
+        href: '/Chosko/policy.html'
+      },
+      onInitialise: function(status) {
+        if (status === cookieconsent.status.allow) {
+          loadAnalytics();
+        }
+      },
+      onStatusChange: function(status) {
+        if (status === cookieconsent.status.allow) {
+          loadAnalytics();
+        }
+      }
+    });
+  }
+
+  function loadAnalytics() {
+    if (window.gtag) return; // Avoid loading multiple times
+    var gtagScript = document.createElement('script');
+    gtagScript.src = 'https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX';
+    gtagScript.async = true;
+    document.head.appendChild(gtagScript);
+
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    window.gtag = gtag;
+    gtag('js', new Date());
+    gtag('config', 'G-XXXXXXXXXX');
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -164,5 +164,6 @@
   <script>
     document.head.innerHTML += '<link rel="canonical" href="' + window.location.protocol + '//' + window.location.host + window.location.pathname + '">';
   </script>
+  <script src="assets/js/monitoring.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add cookie consent banner that loads Google Analytics after user approval
- include monitoring script across all site pages

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689450645b1083319d608ac010d27251