### PR TITLE
Redesign protolab.tech as a scroll-driven generative experience (NEGENTROPY)

### DIFF
--- a/assets/js/negentropy.js
+++ b/assets/js/negentropy.js
@@ -1,0 +1,574 @@
+/*
+ * protolab.tech — NEGENTROPY
+ * One continuous GLSL point-cloud simulation, parameterized by scroll progress.
+ * States: NOISE -> FIELD -> ORDER -> DRIFT -> RESOLVE -> STATE (wordmark).
+ *
+ * Stack: three.js (raw GLSL ShaderMaterial) + Lenis (smooth scroll) +
+ * GSAP ScrollTrigger (scroll-driven copy/state). No build step — the site
+ * stays a static page; three is pulled as an ESM module via import map.
+ */
+import * as THREE from 'three';
+
+const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+const isMobile = window.matchMedia('(max-width: 720px)').matches ||
+  ('ontouchstart' in window && window.innerWidth < 900);
+
+const CHAPTERS = ['NOISE', 'FIELD', 'ORDER', 'DRIFT', 'RESOLVE', 'STATE'];
+
+// Accent palette per chapter: steel -> cyan -> white.
+const ACCENTS = ['#5b6b7a', '#6f8aa3', '#5f9bb0', '#57c9c2', '#9fe8e2', '#eef3f6'];
+// Mobile locks a single accent.
+const MOBILE_ACCENT = '#57c9c2';
+
+const COUNT = isMobile ? 13000 : 52000;
+
+const dom = {
+  canvas: document.getElementById('gl'),
+  boot: document.querySelector('.boot'),
+  hint: document.querySelector('.scroll-hint'),
+  idx: Array.from(document.querySelectorAll('.hud-tr .idx')),
+  fill: document.querySelector('.hud-tr .fill'),
+  pct: document.querySelector('.hud-tr .pct'),
+  secnum: document.querySelector('.hud-bl .secnum'),
+  secname: document.querySelector('.hud-bl .secname'),
+  cx: document.querySelector('.hud-bl .cx'),
+  cy: document.querySelector('.hud-bl .cy'),
+  fps: document.querySelector('.hud-br .fps'),
+  ncount: document.querySelector('.hud-br .ncount'),
+  npoints: document.querySelector('.npoints'),
+  lines: Array.from(document.querySelectorAll('.chapter .line')),
+  sections: Array.from(document.querySelectorAll('.chapter')),
+};
+
+/* ----------------------------------------------------------------------------
+ * Build the wordmark target positions by rasterizing "protolab.tech" to a
+ * canvas and sampling its filled pixels. Returns a Float32Array of length 3*n.
+ * ------------------------------------------------------------------------- */
+function buildWordmarkTargets(count) {
+  const cw = 1024, ch = 256;
+  const c = document.createElement('canvas');
+  c.width = cw;
+  c.height = ch;
+  const ctx = c.getContext('2d');
+  ctx.fillStyle = '#000';
+  ctx.fillRect(0, 0, cw, ch);
+  ctx.fillStyle = '#fff';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.font = '600 150px "Space Grotesk", system-ui, sans-serif';
+  const word = 'protolab.tech';
+  ctx.fillText(word, cw / 2, ch / 2 + 6);
+  const textWpx = ctx.measureText(word).width;
+
+  const data = ctx.getImageData(0, 0, cw, ch).data;
+  const filled = [];
+  // sample on a small stride for performance, keep coords that are lit
+  for (let y = 0; y < ch; y += 2) {
+    for (let x = 0; x < cw; x += 2) {
+      if (data[(y * cw + x) * 4] > 128) filled.push(x, y);
+    }
+  }
+
+  // Bake in normalized canvas space: full canvas width spans 1.0 unit.
+  // World position is (xy * uTextScale) so the cloud can be matched to the
+  // on-screen wordmark size at runtime, aspect preserved.
+  const out = new Float32Array(count * 3);
+  const n = filled.length / 2;
+  if (n === 0) return { array: out, textWpx, cw };
+
+  for (let i = 0; i < count; i++) {
+    const s = (Math.random() * n) | 0;
+    const px = filled[s * 2];
+    const py = filled[s * 2 + 1];
+    const jx = (Math.random() - 0.5) * 1.6;
+    const jy = (Math.random() - 0.5) * 1.6;
+    out[i * 3] = (px + jx) / cw - 0.5;
+    out[i * 3 + 1] = -((py + jy) / cw - (ch / cw) * 0.5);
+    out[i * 3 + 2] = (Math.random() - 0.5) * 0.03;
+  }
+  return { array: out, textWpx, cw };
+}
+
+/* ----------------------------------------------------------------------------
+ * GLSL
+ * ------------------------------------------------------------------------- */
+const VERT = /* glsl */`
+uniform float uTime;
+uniform float uProgress;
+uniform float uSize;
+uniform float uPixelRatio;
+uniform vec3  uAccent;
+uniform float uTimeScale;
+uniform float uTextScale;
+
+attribute vec3  aSeed;
+attribute vec3  aGrid;
+attribute vec3  aText;
+attribute float aId;
+
+varying float vAlpha;
+varying vec3  vColor;
+varying float vGlow;
+
+vec4 permute(vec4 x){return mod(((x*34.0)+1.0)*x,289.0);}
+vec4 taylorInvSqrt(vec4 r){return 1.79284291400159 - 0.85373472095314 * r;}
+float snoise(vec3 v){
+  const vec2 C = vec2(1.0/6.0, 1.0/3.0);
+  const vec4 D = vec4(0.0, 0.5, 1.0, 2.0);
+  vec3 i  = floor(v + dot(v, C.yyy));
+  vec3 x0 = v - i + dot(i, C.xxx);
+  vec3 g = step(x0.yzx, x0.xyz);
+  vec3 l = 1.0 - g;
+  vec3 i1 = min(g.xyz, l.zxy);
+  vec3 i2 = max(g.xyz, l.zxy);
+  vec3 x1 = x0 - i1 + C.xxx;
+  vec3 x2 = x0 - i2 + C.yyy;
+  vec3 x3 = x0 - D.yyy;
+  i = mod(i, 289.0);
+  vec4 p = permute(permute(permute(
+            i.z + vec4(0.0, i1.z, i2.z, 1.0))
+          + i.y + vec4(0.0, i1.y, i2.y, 1.0))
+          + i.x + vec4(0.0, i1.x, i2.x, 1.0));
+  float n_ = 0.142857142857;
+  vec3 ns = n_ * D.wyz - D.xzx;
+  vec4 j = p - 49.0 * floor(p * ns.z * ns.z);
+  vec4 x_ = floor(j * ns.z);
+  vec4 y_ = floor(j - 7.0 * x_);
+  vec4 x = x_ * ns.x + ns.yyyy;
+  vec4 y = y_ * ns.x + ns.yyyy;
+  vec4 h = 1.0 - abs(x) - abs(y);
+  vec4 b0 = vec4(x.xy, y.xy);
+  vec4 b1 = vec4(x.zw, y.zw);
+  vec4 s0 = floor(b0) * 2.0 + 1.0;
+  vec4 s1 = floor(b1) * 2.0 + 1.0;
+  vec4 sh = -step(h, vec4(0.0));
+  vec4 a0 = b0.xzyw + s0.xzyw * sh.xxyy;
+  vec4 a1 = b1.xzyw + s1.xzyw * sh.zzww;
+  vec3 p0 = vec3(a0.xy, h.x);
+  vec3 p1 = vec3(a0.zw, h.y);
+  vec3 p2 = vec3(a1.xy, h.z);
+  vec3 p3 = vec3(a1.zw, h.w);
+  vec4 norm = taylorInvSqrt(vec4(dot(p0,p0), dot(p1,p1), dot(p2,p2), dot(p3,p3)));
+  p0 *= norm.x; p1 *= norm.y; p2 *= norm.z; p3 *= norm.w;
+  vec4 m = max(0.6 - vec4(dot(x0,x0), dot(x1,x1), dot(x2,x2), dot(x3,x3)), 0.0);
+  m = m * m;
+  return 42.0 * dot(m * m, vec4(dot(p0,x0), dot(p1,x1), dot(p2,x2), dot(p3,x3)));
+}
+
+vec3 snoiseVec3(vec3 x){
+  return vec3(
+    snoise(x),
+    snoise(x + vec3(123.4, 256.7, -78.9)),
+    snoise(x + vec3(-31.2, 98.5, 201.1))
+  );
+}
+
+vec3 curl(vec3 p){
+  const float e = 0.12;
+  vec3 dx = vec3(e, 0.0, 0.0);
+  vec3 dy = vec3(0.0, e, 0.0);
+  vec3 dz = vec3(0.0, 0.0, e);
+  vec3 px0 = snoiseVec3(p - dx), px1 = snoiseVec3(p + dx);
+  vec3 py0 = snoiseVec3(p - dy), py1 = snoiseVec3(p + dy);
+  vec3 pz0 = snoiseVec3(p - dz), pz1 = snoiseVec3(p + dz);
+  float x = (py1.z - py0.z) - (pz1.y - pz0.y);
+  float y = (pz1.x - pz0.x) - (px1.z - px0.z);
+  float z = (px1.y - px0.y) - (py1.x - py0.x);
+  return vec3(x, y, z) / (2.0 * e);
+}
+
+// --- the six states of the single system ---
+
+vec3 stateNoise(float t){
+  vec3 base = aSeed * 23.0;
+  vec3 flow = curl(aSeed * 0.22 + t * 0.05) * 7.0;
+  return base + flow;
+}
+
+vec3 stateField(float t){
+  float x = aGrid.x * 1.3;
+  float z = aGrid.z * 1.3;
+  float y = sin(x * 0.18 + t * 0.35) * 2.3 + cos(z * 0.2 - t * 0.28) * 2.0;
+  y += snoise(vec3(x * 0.1, z * 0.1, t * 0.06)) * 1.6;
+  return vec3(x, y + aGrid.y * 0.04, z);
+}
+
+vec3 stateOrder(float t){
+  // a held lattice, with an almost-imperceptible settle
+  return aGrid + curl(aGrid * 0.04 + t * 0.02) * 0.18;
+}
+
+vec3 stateDrift(float t){
+  vec3 d = curl(aGrid * 0.06 + t * 0.05) * (3.2 + 1.6 * sin(t * 0.2 + aId * 6.0));
+  return aGrid + d;
+}
+
+vec3 stateResolve(float t){
+  vec3 dir = normalize(aSeed + 0.0001);
+  float r = 12.5 + snoise(aSeed * 1.5 + t * 0.1) * 0.9;
+  vec3 sph = dir * r;
+  float a = t * 0.16;
+  float ca = cos(a), sa = sin(a);
+  sph.xz = mat2(ca, -sa, sa, ca) * sph.xz;
+  return sph;
+}
+
+vec3 stateWordmark(float t){
+  vec3 p = aText * uTextScale;
+  p.z += sin(t * 0.6 + aId * 30.0) * 0.22;
+  p.x += sin(t * 0.4 + aId * 12.0) * 0.04;
+  return p;
+}
+
+vec3 posForIndex(int i, float t){
+  if (i <= 0) return stateNoise(t);
+  else if (i == 1) return stateField(t);
+  else if (i == 2) return stateOrder(t);
+  else if (i == 3) return stateDrift(t);
+  else if (i == 4) return stateResolve(t);
+  return stateWordmark(t);
+}
+
+void main(){
+  float t = uTime * uTimeScale;
+
+  float segf = clamp(uProgress, 0.0, 1.0) * 5.0;
+  float seg = floor(segf);
+  float f = smoothstep(0.0, 1.0, fract(segf));
+  int i0 = int(seg);
+  int i1 = int(min(seg + 1.0, 5.0));
+
+  vec3 pA = posForIndex(i0, t);
+  vec3 pB = posForIndex(i1, t);
+  vec3 pos = mix(pA, pB, f);
+
+  vec4 mvPosition = modelViewMatrix * vec4(pos, 1.0);
+  gl_Position = projectionMatrix * mvPosition;
+
+  float size = uSize * (0.6 + aId * 1.0);
+  gl_PointSize = size * uPixelRatio * (62.0 / -mvPosition.z);
+  gl_PointSize = clamp(gl_PointSize, 0.5, 16.0);
+
+  float depth = clamp((-mvPosition.z - 6.0) / 64.0, 0.0, 1.0);
+  vAlpha = 1.0 - depth * 0.82;
+
+  // cooler, dimmer points fade toward background; a few read brighter
+  vColor = uAccent * (0.7 + aId * 0.5);
+  vGlow = smoothstep(0.7, 1.0, aId);
+}
+`;
+
+const FRAG = /* glsl */`
+precision highp float;
+uniform float uOpacity;
+varying float vAlpha;
+varying vec3  vColor;
+varying float vGlow;
+
+void main(){
+  vec2 uv = gl_PointCoord - 0.5;
+  float d = length(uv);
+  float core = smoothstep(0.5, 0.0, d);
+  float alpha = core * vAlpha * uOpacity;
+  if (alpha < 0.003) discard;
+  vec3 col = vColor + vGlow * 0.18;
+  gl_FragColor = vec4(col, alpha);
+}
+`;
+
+/* ----------------------------------------------------------------------------
+ * Engine
+ * ------------------------------------------------------------------------- */
+function start() {
+  let renderer;
+  try {
+    renderer = new THREE.WebGLRenderer({
+      canvas: dom.canvas,
+      antialias: false,
+      alpha: false,
+      powerPreference: 'high-performance',
+    });
+  } catch (e) {
+    return fallback();
+  }
+  if (!renderer || !renderer.getContext()) return fallback();
+
+  const pixelRatio = Math.min(window.devicePixelRatio || 1, isMobile ? 2 : 1.75);
+  renderer.setPixelRatio(pixelRatio);
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.setClearColor(0x050507, 1);
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(46, window.innerWidth / window.innerHeight, 0.1, 200);
+  camera.position.set(0, 0, 40);
+
+  const group = new THREE.Group();
+  // On narrow/portrait screens the field is scaled down so the whole structure
+  // stays in frame; the wordmark match compensates so it still resolves cleanly.
+  const SIM_SCALE = isMobile ? 0.58 : 1.0;
+  group.scale.setScalar(SIM_SCALE);
+  scene.add(group);
+
+  // attributes
+  const seeds = new Float32Array(COUNT * 3);
+  const grid = new Float32Array(COUNT * 3);
+  const ids = new Float32Array(COUNT);
+
+  const side = Math.ceil(Math.cbrt(COUNT));
+  const L = 26;
+  for (let i = 0; i < COUNT; i++) {
+    // random seed vector for noise scatter / sphere direction
+    seeds[i * 3] = Math.random() * 2 - 1;
+    seeds[i * 3 + 1] = Math.random() * 2 - 1;
+    seeds[i * 3 + 2] = Math.random() * 2 - 1;
+
+    // lattice
+    const ix = i % side;
+    const iy = Math.floor(i / side) % side;
+    const iz = Math.floor(i / (side * side));
+    grid[i * 3] = (ix / (side - 1) - 0.5) * L;
+    grid[i * 3 + 1] = (iy / (side - 1) - 0.5) * L;
+    grid[i * 3 + 2] = (iz / (side - 1) - 0.5) * L;
+
+    ids[i] = Math.random();
+  }
+  const textData = buildWordmarkTargets(COUNT);
+
+  const geo = new THREE.BufferGeometry();
+  // position attribute required by three; actual position is computed in shader
+  geo.setAttribute('position', new THREE.BufferAttribute(new Float32Array(COUNT * 3), 3));
+  geo.setAttribute('aSeed', new THREE.BufferAttribute(seeds, 3));
+  geo.setAttribute('aGrid', new THREE.BufferAttribute(grid, 3));
+  geo.setAttribute('aText', new THREE.BufferAttribute(textData.array, 3));
+  geo.setAttribute('aId', new THREE.BufferAttribute(ids, 1));
+  geo.boundingSphere = new THREE.Sphere(new THREE.Vector3(0, 0, 0), 80);
+
+  const uniforms = {
+    uTime: { value: 0 },
+    uProgress: { value: 0 },
+    uSize: { value: isMobile ? 3.0 : 2.3 },
+    uOpacity: { value: 0.92 },
+    uPixelRatio: { value: pixelRatio },
+    uAccent: { value: new THREE.Color(isMobile ? MOBILE_ACCENT : ACCENTS[0]) },
+    uTimeScale: { value: prefersReduced ? 0.25 : 1.0 },
+    uTextScale: { value: 44 },
+  };
+
+  const RESOLVE_Z = 34; // camera z when the system fully resolves
+
+  // Match the particle wordmark to the on-screen crisp wordmark so the cloud
+  // resolves precisely onto it. Re-run on resize / font load.
+  const wordmarkEl = document.querySelector('#state .wordmark');
+  function computeTextScale() {
+    const w = window.innerWidth, h = window.innerHeight;
+    const visW = 2 * Math.tan((46 * Math.PI / 180) / 2) * RESOLVE_Z * (w / h);
+    const worldPerPx = visW / w;
+    let wcss = 0;
+    if (wordmarkEl) wcss = wordmarkEl.getBoundingClientRect().width;
+    if (!wcss) wcss = w * 0.6;
+    const worldTextW = wcss * worldPerPx;
+    // textData.textWpx / cw = fraction of canvas the glyphs occupy.
+    // Divide by SIM_SCALE so the group scale cancels out and the wordmark still
+    // lands exactly on the crisp HTML wordmark.
+    uniforms.uTextScale.value = worldTextW * (textData.cw / textData.textWpx) / SIM_SCALE;
+  }
+  computeTextScale();
+  if (document.fonts && document.fonts.ready) {
+    document.fonts.ready.then(computeTextScale);
+  }
+
+  const material = new THREE.ShaderMaterial({
+    uniforms,
+    vertexShader: VERT,
+    fragmentShader: FRAG,
+    transparent: true,
+    depthTest: false,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending,
+  });
+
+  const points = new THREE.Points(geo, material);
+  points.frustumCulled = false;
+  group.add(points);
+
+  // boot done
+  if (dom.boot) {
+    dom.boot.classList.add('gone');
+    setTimeout(() => dom.boot && dom.boot.remove(), 900);
+  }
+  if (dom.npoints) dom.npoints.textContent = COUNT.toLocaleString('en-US');
+  if (dom.ncount) dom.ncount.textContent = COUNT.toLocaleString('en-US');
+
+  // ---- scroll progress & HUD state ----
+  let targetProgress = 0;
+  let progress = 0;
+  let activeChapter = -1;
+  const targetAccent = new THREE.Color(isMobile ? MOBILE_ACCENT : ACCENTS[0]);
+  const pointer = { x: 0, y: 0, tx: 0, ty: 0 };
+
+  function readScroll() {
+    const max = document.documentElement.scrollHeight - window.innerHeight;
+    targetProgress = max > 0 ? Math.min(Math.max(window.scrollY / max, 0), 1) : 0;
+  }
+
+  function setChapter(i) {
+    if (i === activeChapter) return;
+    activeChapter = i;
+    dom.idx.forEach((el, k) => {
+      el.classList.toggle('active', k === i);
+      el.classList.toggle('past', k < i);
+    });
+    if (dom.secnum) dom.secnum.textContent = String(i + 1).padStart(3, '0');
+    if (dom.secname) dom.secname.textContent = CHAPTERS[i];
+    if (!isMobile) targetAccent.set(ACCENTS[i]);
+    document.documentElement.style.setProperty('--accent', isMobile ? MOBILE_ACCENT : ACCENTS[i]);
+  }
+
+  // copy reveal + active-chapter detection driven by live section geometry
+  // (robust across native scroll, Lenis, and reduced-motion).
+  function updateCopy() {
+    const vh = window.innerHeight;
+    let closest = 0;
+    let closestDist = Infinity;
+    for (let k = 0; k < dom.sections.length; k++) {
+      const sec = dom.sections[k];
+      const line = dom.lines[k];
+      if (!line) continue;
+      const rect = sec.getBoundingClientRect();
+      const center = rect.top + rect.height / 2;
+      const dist = (center - vh / 2) / vh; // 0 when centered
+      if (Math.abs(dist) < closestDist) {
+        closestDist = Math.abs(dist);
+        closest = k;
+      }
+      let o, ty;
+      if (k === dom.sections.length - 1) {
+        // STATE: rise in and hold
+        o = THREE.MathUtils.clamp(1 - dist * 1.4, 0, 1);
+        ty = THREE.MathUtils.clamp(dist, -0.4, 1) * 26;
+      } else {
+        o = THREE.MathUtils.clamp(1 - Math.abs(dist) * 1.7, 0, 1);
+        ty = dist * 30;
+      }
+      line.style.opacity = o.toFixed(3);
+      line.style.transform = `translateY(${ty.toFixed(1)}px)`;
+    }
+    setChapter(closest);
+  }
+
+  // ScrollTrigger keeps Lenis and the scroll system in sync (smooth,
+  // scroll-driven state); chapter/morph state is read from geometry each frame.
+  if (window.gsap && window.ScrollTrigger) {
+    window.gsap.registerPlugin(window.ScrollTrigger);
+  }
+
+  // ---- Lenis smooth scroll (skip when reduced motion) ----
+  let lenis = null;
+  if (!prefersReduced && window.Lenis) {
+    lenis = new window.Lenis({
+      duration: 1.15,
+      smoothWheel: true,
+      lerp: 0.09,
+      wheelMultiplier: 0.9,
+    });
+    if (window.ScrollTrigger) lenis.on('scroll', window.ScrollTrigger.update);
+  }
+
+  // pointer parallax
+  if (!isMobile) {
+    window.addEventListener('pointermove', (e) => {
+      pointer.tx = (e.clientX / window.innerWidth - 0.5);
+      pointer.ty = (e.clientY / window.innerHeight - 0.5);
+    }, { passive: true });
+  }
+
+  // hide scroll hint after first interaction
+  let hinted = false;
+  function killHint() {
+    if (hinted || !dom.hint) return;
+    hinted = true;
+    dom.hint.style.opacity = '0';
+  }
+  window.addEventListener('scroll', () => { readScroll(); if (window.scrollY > 30) killHint(); }, { passive: true });
+  window.addEventListener('wheel', killHint, { passive: true });
+  window.addEventListener('touchmove', killHint, { passive: true });
+
+  // resize
+  function onResize() {
+    const w = window.innerWidth, h = window.innerHeight;
+    renderer.setSize(w, h);
+    camera.aspect = w / h;
+    camera.updateProjectionMatrix();
+    computeTextScale();
+    if (window.ScrollTrigger) window.ScrollTrigger.refresh();
+    readScroll();
+  }
+  window.addEventListener('resize', onResize);
+
+  // ---- main loop ----
+  const clock = new THREE.Clock();
+  let lastT = performance.now();
+
+  function frame(now) {
+    if (lenis) lenis.raf(now);
+
+    const dt = (now - lastT) / 1000;
+    lastT = now;
+
+    // ease progress toward scroll target for buttery morph
+    progress += (targetProgress - progress) * 0.08;
+
+    uniforms.uTime.value = clock.getElapsedTime();
+    uniforms.uProgress.value = progress;
+
+    // accent ease
+    uniforms.uAccent.value.lerp(targetAccent, 0.04);
+
+    // group motion: slow auto drift + scroll twist + pointer parallax,
+    // damped to zero as the system resolves so the wordmark faces the camera.
+    pointer.x += (pointer.tx - pointer.x) * 0.05;
+    pointer.y += (pointer.ty - pointer.y) * 0.05;
+    const ts = prefersReduced ? 0.15 : 1.0;
+    const damp = 1 - THREE.MathUtils.smoothstep(progress, 0.8, 1.0);
+    group.rotation.y = (now * 0.00004 * ts + pointer.x * 0.5 + progress * 0.45) * damp;
+    group.rotation.x = (pointer.y * 0.35 + Math.sin(now * 0.0002 * ts) * 0.05) * damp;
+
+    // camera eases in and re-centers as the system resolves
+    camera.position.z = 40 - (40 - RESOLVE_Z) * THREE.MathUtils.smoothstep(progress, 0.0, 1.0);
+    camera.position.x = pointer.x * 2.0 * damp;
+    camera.position.y = -pointer.y * 1.2 * damp;
+    camera.lookAt(0, 0, 0);
+
+    renderer.render(scene, camera);
+
+    // HUD readouts
+    if (dom.fill) dom.fill.style.width = (progress * 100).toFixed(2) + '%';
+    if (dom.pct) dom.pct.textContent = progress.toFixed(3);
+    if (dom.cx) dom.cx.textContent = (pointer.x >= 0 ? '+' : '') + pointer.x.toFixed(2);
+    if (dom.cy) dom.cy.textContent = (pointer.y >= 0 ? '+' : '') + pointer.y.toFixed(2);
+    if (dom.fps) dom.fps.textContent = dt.toFixed(3);
+
+    updateCopy();
+
+    requestAnimationFrame(frame);
+  }
+
+  readScroll();
+  updateCopy();
+  setChapter(0);
+  requestAnimationFrame(frame);
+}
+
+/* ----------------------------------------------------------------------------
+ * Fallback when WebGL is unavailable: reveal copy statically, kill the canvas.
+ * ------------------------------------------------------------------------- */
+function fallback() {
+  document.documentElement.style.setProperty('--accent', MOBILE_ACCENT);
+  if (dom.canvas) dom.canvas.style.display = 'none';
+  if (dom.boot) dom.boot.remove();
+  if (dom.npoints) dom.npoints.textContent = '0';
+  dom.lines.forEach((l) => { l.style.opacity = '1'; l.style.transform = 'none'; });
+  if (dom.idx[0]) dom.idx[0].classList.add('active');
+}
+
+start();

--- a/index.html
+++ b/index.html
@@ -3,58 +3,57 @@
 
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <meta name="description"
-    content="Professional 3D printing, laser cutting, and CNC engraving services for creative product prototyping." />
-  <meta name="keywords" content="3D printing, laser cutting, CNC engraving, prototyping, product design" />
+    content="protolab.tech — a solving-force for any system, any problem." />
   <meta name="author" content="protolab.tech" />
-  <meta name="theme-color" content="#0a0a0a" />
+  <meta name="theme-color" content="#050507" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Protolab - Innovative Prototyping Solutions" />
-  <meta property="og:description"
-    content="Professional 3D printing, laser cutting, and CNC engraving services for creative product prototyping." />
+  <meta property="og:title" content="protolab.tech" />
+  <meta property="og:description" content="A solving-force for any system, any problem." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://protolab.tech" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Protolab - Innovative Prototyping Solutions" />
-  <meta name="twitter:description"
-    content="Professional 3D printing, laser cutting, and CNC engraving services for creative product prototyping." />
+  <meta name="twitter:title" content="protolab.tech" />
+  <meta name="twitter:description" content="A solving-force for any system, any problem." />
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml"
-    href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔧</text></svg>" />
+    href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='%23050507'/><circle cx='50' cy='50' r='3' fill='%23eef3f6'/><circle cx='28' cy='34' r='1.6' fill='%2357c9c2'/><circle cx='72' cy='66' r='1.6' fill='%2357c9c2'/><circle cx='70' cy='30' r='1.2' fill='%236f8aa3'/><circle cx='32' cy='70' r='1.2' fill='%236f8aa3'/></svg>" />
 
-  <title>Protolab - Innovative Prototyping Solutions</title>
+  <title>protolab.tech</title>
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
-    href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
     rel="stylesheet">
 
+  <!-- three.js as ESM via import map (no build step; keeps the static stack) -->
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js"
+      }
+    }
+  </script>
+
   <style>
-    /* CSS Custom Properties */
     :root {
-      --bg-primary: #0a0a0a;
-      --bg-secondary: #111111;
-      --bg-card: #161616;
-      --accent-blue: #3b82f6;
-      --accent-blue-light: #60a5fa;
-      --accent-glow: rgba(59, 130, 246, 0.4);
-      --text-primary: #fafafa;
-      --text-secondary: #a3a3a3;
-      --text-muted: #737373;
-      --border-subtle: rgba(255, 255, 255, 0.08);
-      --border-hover: rgba(255, 255, 255, 0.15);
-      --glass-bg: rgba(255, 255, 255, 0.03);
-      --glass-border: rgba(255, 255, 255, 0.1);
+      --bg: #050507;
+      --ink: #e8edf2;
+      --ink-dim: #707a85;
+      --ink-faint: #3a424c;
+      /* accent is driven live from JS per chapter (steel -> cyan -> white) */
+      --accent: #5b6b7a;
+      --hud-line: rgba(232, 237, 242, 0.12);
+      --hud-line-strong: rgba(232, 237, 242, 0.28);
     }
 
-    /* Reset & Base */
     *,
     *::before,
     *::after {
@@ -63,1257 +62,588 @@
       box-sizing: border-box;
     }
 
-    html {
-      scroll-behavior: smooth;
+    html,
+    body {
+      background: var(--bg);
+      color: var(--ink);
+      -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
     }
 
     body {
-      font-family: 'Inter', system-ui, sans-serif;
-      background: var(--bg-primary);
-      color: var(--text-primary);
-      line-height: 1.6;
+      font-family: 'Space Grotesk', system-ui, sans-serif;
       overflow-x: hidden;
-      -webkit-font-smoothing: antialiased;
+      cursor: default;
     }
 
-    /* Scrollbar */
-    ::-webkit-scrollbar {
-      width: 8px;
+    .mono {
+      font-family: 'JetBrains Mono', ui-monospace, monospace;
+      font-weight: 400;
+      letter-spacing: 0.04em;
     }
 
-    ::-webkit-scrollbar-track {
-      background: var(--bg-primary);
-    }
-
-    ::-webkit-scrollbar-thumb {
-      background: #333;
-      border-radius: 4px;
-    }
-
-    ::-webkit-scrollbar-thumb:hover {
-      background: #444;
-    }
-
-    /* Typography */
-    .font-display {
-      font-family: 'Space Grotesk', sans-serif;
-    }
-
-    /* Animated Background */
-    .animated-bg {
+    /* ============ WebGL canvas (fixed, behind everything) ============ */
+    #gl {
       position: fixed;
       inset: 0;
-      z-index: -1;
-      overflow: hidden;
-    }
-
-    .gradient-orb {
-      position: absolute;
-      border-radius: 50%;
-      filter: blur(80px);
-      opacity: 0.5;
-      animation: float 20s ease-in-out infinite;
-    }
-
-    .orb-1 {
-      width: 600px;
-      height: 600px;
-      background: radial-gradient(circle, rgba(59, 130, 246, 0.3) 0%, transparent 70%);
-      top: -200px;
-      right: -200px;
-      animation-delay: 0s;
-    }
-
-    .orb-2 {
-      width: 500px;
-      height: 500px;
-      background: radial-gradient(circle, rgba(139, 92, 246, 0.25) 0%, transparent 70%);
-      bottom: -150px;
-      left: -150px;
-      animation-delay: -7s;
-    }
-
-    .orb-3 {
-      width: 400px;
-      height: 400px;
-      background: radial-gradient(circle, rgba(59, 130, 246, 0.2) 0%, transparent 70%);
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      animation-delay: -14s;
-    }
-
-    @keyframes float {
-
-      0%,
-      100% {
-        transform: translate(0, 0) scale(1);
-      }
-
-      25% {
-        transform: translate(30px, -30px) scale(1.05);
-      }
-
-      50% {
-        transform: translate(-20px, 20px) scale(0.95);
-      }
-
-      75% {
-        transform: translate(20px, 10px) scale(1.02);
-      }
-    }
-
-    /* Floating Particles */
-    .particles {
-      position: fixed;
-      inset: 0;
-      z-index: -1;
-      pointer-events: none;
-    }
-
-    .particle {
-      position: absolute;
-      width: 4px;
-      height: 4px;
-      background: var(--accent-blue);
-      border-radius: 50%;
-      opacity: 0.3;
-      animation: particle-float 15s ease-in-out infinite;
-    }
-
-    .particle:nth-child(1) {
-      left: 10%;
-      top: 20%;
-      animation-delay: 0s;
-    }
-
-    .particle:nth-child(2) {
-      left: 20%;
-      top: 80%;
-      animation-delay: -3s;
-    }
-
-    .particle:nth-child(3) {
-      left: 60%;
-      top: 40%;
-      animation-delay: -6s;
-    }
-
-    .particle:nth-child(4) {
-      left: 80%;
-      top: 60%;
-      animation-delay: -9s;
-    }
-
-    .particle:nth-child(5) {
-      left: 40%;
-      top: 90%;
-      animation-delay: -12s;
-    }
-
-    .particle:nth-child(6) {
-      left: 90%;
-      top: 10%;
-      animation-delay: -2s;
-    }
-
-    .particle:nth-child(7) {
-      left: 5%;
-      top: 50%;
-      animation-delay: -5s;
-    }
-
-    .particle:nth-child(8) {
-      left: 70%;
-      top: 75%;
-      animation-delay: -8s;
-    }
-
-    @keyframes particle-float {
-
-      0%,
-      100% {
-        transform: translateY(0) scale(1);
-        opacity: 0.3;
-      }
-
-      50% {
-        transform: translateY(-100px) scale(1.5);
-        opacity: 0.6;
-      }
-    }
-
-    /* Glassmorphism Header */
-    header {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      z-index: 1000;
-      background: rgba(10, 10, 10, 0.8);
-      backdrop-filter: blur(20px);
-      -webkit-backdrop-filter: blur(20px);
-      border-bottom: 1px solid var(--glass-border);
-      transition: all 0.3s ease;
-    }
-
-    header.scrolled {
-      background: rgba(10, 10, 10, 0.95);
-      box-shadow: 0 4px 30px rgba(0, 0, 0, 0.3);
-    }
-
-    .header-container {
-      max-width: 1200px;
-      margin: 0 auto;
-      padding: 16px 24px;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-    }
-
-    .logo {
-      font-family: 'Space Grotesk', sans-serif;
-      font-size: 24px;
-      font-weight: 700;
-      color: var(--text-primary);
-      text-decoration: none;
-      letter-spacing: -0.5px;
-      transition: opacity 0.3s ease;
-    }
-
-    .logo:hover {
-      opacity: 0.8;
-    }
-
-    .logo span {
-      background: linear-gradient(135deg, var(--accent-blue-light), var(--accent-blue));
-      -webkit-background-clip: text;
-      background-clip: text;
-      color: transparent;
-    }
-
-    nav ul {
-      display: flex;
-      list-style: none;
-      gap: 32px;
-    }
-
-    nav a {
-      color: var(--text-secondary);
-      text-decoration: none;
-      font-weight: 500;
-      font-size: 14px;
-      transition: color 0.3s ease;
-      position: relative;
-    }
-
-    nav a::after {
-      content: '';
-      position: absolute;
-      bottom: -4px;
-      left: 0;
-      width: 0;
-      height: 2px;
-      background: var(--accent-blue);
-      transition: width 0.3s ease;
-    }
-
-    nav a:hover {
-      color: var(--text-primary);
-    }
-
-    nav a:hover::after {
-      width: 100%;
-    }
-
-    .cta-btn {
-      background: var(--accent-blue);
-      color: white;
-      padding: 10px 20px;
-      border-radius: 8px;
-      text-decoration: none;
-      font-weight: 600;
-      font-size: 14px;
-      transition: all 0.3s ease;
-      box-shadow: 0 0 20px var(--accent-glow);
-    }
-
-    .cta-btn:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 0 30px var(--accent-glow), 0 10px 30px rgba(0, 0, 0, 0.3);
-    }
-
-    /* Hero Section */
-    .hero {
-      min-height: 100vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 120px 24px 80px;
-      position: relative;
-    }
-
-    .hero-content {
-      max-width: 900px;
-      text-align: center;
-    }
-
-    .hero-badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      background: var(--glass-bg);
-      border: 1px solid var(--glass-border);
-      padding: 8px 16px;
-      border-radius: 100px;
-      font-size: 13px;
-      color: var(--text-secondary);
-      margin-bottom: 32px;
-      animation: fadeInUp 0.8s ease-out;
-    }
-
-    .hero-badge .dot {
-      width: 8px;
-      height: 8px;
-      background: #22c55e;
-      border-radius: 50%;
-      animation: pulse 2s ease-in-out infinite;
-    }
-
-    @keyframes pulse {
-
-      0%,
-      100% {
-        opacity: 1;
-        transform: scale(1);
-      }
-
-      50% {
-        opacity: 0.5;
-        transform: scale(1.2);
-      }
-    }
-
-    .hero h1 {
-      font-family: 'Space Grotesk', sans-serif;
-      font-size: clamp(40px, 8vw, 80px);
-      font-weight: 700;
-      line-height: 1.1;
-      margin-bottom: 24px;
-      letter-spacing: -2px;
-      animation: fadeInUp 0.8s ease-out 0.1s backwards;
-    }
-
-    .hero h1 .gradient-text {
-      background: linear-gradient(135deg, var(--accent-blue-light) 0%, var(--accent-blue) 50%, #8b5cf6 100%);
-      -webkit-background-clip: text;
-      background-clip: text;
-      color: transparent;
-      background-size: 200% 200%;
-      animation: gradient-shift 5s ease infinite;
-    }
-
-    @keyframes gradient-shift {
-
-      0%,
-      100% {
-        background-position: 0% 50%;
-      }
-
-      50% {
-        background-position: 100% 50%;
-      }
-    }
-
-    .hero p {
-      font-size: clamp(16px, 2vw, 20px);
-      color: var(--text-secondary);
-      max-width: 600px;
-      margin: 0 auto 40px;
-      animation: fadeInUp 0.8s ease-out 0.2s backwards;
-    }
-
-    .hero-actions {
-      display: flex;
-      gap: 16px;
-      justify-content: center;
-      flex-wrap: wrap;
-      animation: fadeInUp 0.8s ease-out 0.3s backwards;
-    }
-
-    .btn-primary {
-      background: var(--accent-blue);
-      color: white;
-      padding: 14px 28px;
-      border-radius: 10px;
-      text-decoration: none;
-      font-weight: 600;
-      font-size: 15px;
-      transition: all 0.3s ease;
-      box-shadow: 0 0 30px var(--accent-glow);
-      animation: pulse-glow 3s ease-in-out infinite;
-    }
-
-    @keyframes pulse-glow {
-
-      0%,
-      100% {
-        box-shadow: 0 0 20px var(--accent-glow);
-      }
-
-      50% {
-        box-shadow: 0 0 40px var(--accent-glow), 0 0 60px rgba(59, 130, 246, 0.2);
-      }
-    }
-
-    .btn-primary:hover {
-      transform: translateY(-3px);
-      box-shadow: 0 0 50px var(--accent-glow), 0 15px 40px rgba(0, 0, 0, 0.4);
-    }
-
-    .btn-secondary {
-      background: var(--glass-bg);
-      border: 1px solid var(--glass-border);
-      color: var(--text-primary);
-      padding: 14px 28px;
-      border-radius: 10px;
-      text-decoration: none;
-      font-weight: 600;
-      font-size: 15px;
-      transition: all 0.3s ease;
-    }
-
-    .btn-secondary:hover {
-      background: rgba(255, 255, 255, 0.08);
-      border-color: var(--border-hover);
-      transform: translateY(-2px);
-    }
-
-    @keyframes fadeInUp {
-      from {
-        opacity: 0;
-        transform: translateY(30px);
-      }
-
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
-    }
-
-    /* Scroll indicator */
-    .scroll-indicator {
-      position: absolute;
-      bottom: 40px;
-      left: 50%;
-      transform: translateX(-50%);
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 8px;
-      color: var(--text-muted);
-      font-size: 12px;
-      animation: fadeInUp 0.8s ease-out 0.5s backwards;
-    }
-
-    .scroll-indicator .mouse {
-      width: 24px;
-      height: 40px;
-      border: 2px solid var(--text-muted);
-      border-radius: 12px;
-      position: relative;
-    }
-
-    .scroll-indicator .mouse::before {
-      content: '';
-      position: absolute;
-      top: 8px;
-      left: 50%;
-      transform: translateX(-50%);
-      width: 4px;
-      height: 8px;
-      background: var(--text-muted);
-      border-radius: 2px;
-      animation: scroll-bounce 2s ease-in-out infinite;
-    }
-
-    @keyframes scroll-bounce {
-
-      0%,
-      100% {
-        transform: translateX(-50%) translateY(0);
-        opacity: 1;
-      }
-
-      50% {
-        transform: translateX(-50%) translateY(10px);
-        opacity: 0.3;
-      }
-    }
-
-    /* Services Section */
-    .services {
-      padding: 100px 24px;
-      position: relative;
-    }
-
-    .section-header {
-      text-align: center;
-      max-width: 600px;
-      margin: 0 auto 60px;
-    }
-
-    .section-label {
-      font-size: 13px;
-      font-weight: 600;
-      color: var(--accent-blue);
-      text-transform: uppercase;
-      letter-spacing: 2px;
-      margin-bottom: 16px;
-    }
-
-    .section-title {
-      font-family: 'Space Grotesk', sans-serif;
-      font-size: clamp(32px, 5vw, 48px);
-      font-weight: 700;
-      letter-spacing: -1px;
-      margin-bottom: 16px;
-    }
-
-    .section-desc {
-      color: var(--text-secondary);
-      font-size: 16px;
-    }
-
-    .services-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-      gap: 24px;
-      max-width: 1200px;
-      margin: 0 auto;
-    }
-
-    .service-card {
-      background: var(--bg-card);
-      border: 1px solid var(--border-subtle);
-      border-radius: 20px;
-      padding: 32px;
-      transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-      position: relative;
-      overflow: hidden;
-    }
-
-    .service-card::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(135deg, rgba(59, 130, 246, 0.1) 0%, transparent 50%);
-      opacity: 0;
-      transition: opacity 0.4s ease;
-    }
-
-    .service-card:hover {
-      transform: translateY(-8px) scale(1.02);
-      border-color: var(--accent-blue);
-      box-shadow: 0 25px 50px rgba(0, 0, 0, 0.4), 0 0 40px var(--accent-glow);
-    }
-
-    .service-card:hover::before {
-      opacity: 1;
-    }
-
-    .service-icon {
-      width: 56px;
-      height: 56px;
-      background: linear-gradient(135deg, var(--accent-blue), #8b5cf6);
-      border-radius: 14px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 28px;
-      margin-bottom: 20px;
-      position: relative;
-      z-index: 1;
-    }
-
-    .service-card h3 {
-      font-family: 'Space Grotesk', sans-serif;
-      font-size: 22px;
-      font-weight: 700;
-      margin-bottom: 12px;
-      position: relative;
-      z-index: 1;
-    }
-
-    .service-card p {
-      color: var(--text-secondary);
-      font-size: 15px;
-      line-height: 1.7;
-      position: relative;
-      z-index: 1;
-    }
-
-    /* Projects Section */
-    .projects {
-      padding: 100px 24px;
-      background: linear-gradient(180deg, var(--bg-primary) 0%, var(--bg-secondary) 100%);
-    }
-
-    .projects-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: 24px;
-      max-width: 1200px;
-      margin: 0 auto;
-    }
-
-    .project-card {
-      background: var(--bg-card);
-      border: 1px solid var(--border-subtle);
-      border-radius: 16px;
-      overflow: hidden;
-      transition: all 0.4s ease;
-      text-decoration: none;
+      width: 100vw;
+      height: 100vh;
+      z-index: 0;
       display: block;
     }
 
-    .project-card:hover {
-      transform: translateY(-8px);
-      border-color: var(--border-hover);
-      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+    /* subtle vignette over the canvas */
+    .vignette {
+      position: fixed;
+      inset: 0;
+      z-index: 1;
+      pointer-events: none;
+      background:
+        radial-gradient(120% 120% at 50% 50%, transparent 55%, rgba(0, 0, 0, 0.55) 100%);
     }
 
-    .project-image {
-      width: 100%;
-      aspect-ratio: 16/10;
-      background: linear-gradient(135deg, var(--bg-secondary), var(--bg-card));
+    /* faint scanline / grain texture for the "instrument" feel */
+    .grain {
+      position: fixed;
+      inset: 0;
+      z-index: 1;
+      pointer-events: none;
+      opacity: 0.05;
+      background-image: repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.5) 0 1px, transparent 1px 3px);
+      mix-blend-mode: overlay;
+    }
+
+    /* ============ Scroll content ============ */
+    main {
+      position: relative;
+      z-index: 2;
+    }
+
+    .chapter {
+      position: relative;
+      min-height: 100vh;
       display: flex;
       align-items: center;
+      padding: 0 clamp(28px, 8vw, 180px);
+      pointer-events: none;
+    }
+
+    .chapter[data-align="right"] {
+      justify-content: flex-end;
+      text-align: right;
+    }
+
+    .chapter[data-align="center"] {
       justify-content: center;
-      font-size: 48px;
-      position: relative;
-      overflow: hidden;
+      text-align: center;
     }
 
-    .project-image::after {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(to top, var(--bg-card), transparent);
-    }
-
-    .project-info {
-      padding: 24px;
-    }
-
-    .project-info h3 {
-      font-family: 'Space Grotesk', sans-serif;
-      font-size: 20px;
-      font-weight: 600;
-      color: var(--text-primary);
-      margin-bottom: 8px;
-    }
-
-    .project-info p {
-      color: var(--text-secondary);
-      font-size: 14px;
-    }
-
-    /* Footer */
-    footer {
-      background: var(--bg-secondary);
-      border-top: 1px solid var(--border-subtle);
-      padding: 60px 24px 24px;
-    }
-
-    .footer-container {
-      max-width: 1200px;
-      margin: 0 auto;
-    }
-
-    .footer-main {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      flex-wrap: wrap;
-      gap: 40px;
-      margin-bottom: 40px;
-    }
-
-    .footer-brand {
-      max-width: 300px;
-    }
-
-    .footer-brand .logo {
-      display: inline-block;
-      margin-bottom: 16px;
-    }
-
-    .footer-brand p {
-      color: var(--text-secondary);
-      font-size: 14px;
-      line-height: 1.7;
-    }
-
-    .footer-links {
-      display: flex;
-      gap: 60px;
-    }
-
-    .footer-col h4 {
-      font-size: 14px;
-      font-weight: 600;
-      margin-bottom: 16px;
-      color: var(--text-primary);
-    }
-
-    .footer-col ul {
-      list-style: none;
-    }
-
-    .footer-col li {
-      margin-bottom: 10px;
-    }
-
-    .footer-col a {
-      color: var(--text-secondary);
-      text-decoration: none;
-      font-size: 14px;
-      transition: color 0.3s ease;
-    }
-
-    .footer-col a:hover {
-      color: var(--text-primary);
-    }
-
-    .footer-bottom {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding-top: 24px;
-      border-top: 1px solid var(--border-subtle);
-      flex-wrap: wrap;
-      gap: 16px;
-    }
-
-    .footer-bottom p {
-      color: var(--text-muted);
-      font-size: 13px;
-    }
-
-    .social-links {
-      display: flex;
-      gap: 16px;
-    }
-
-    .social-links a {
-      color: var(--text-secondary);
-      font-size: 20px;
-      transition: all 0.3s ease;
-    }
-
-    .social-links a:hover {
-      color: var(--accent-blue);
-      transform: translateY(-2px);
-    }
-
-    /* Responsive */
-    @media (max-width: 768px) {
-      nav ul {
-        display: none;
-      }
-
-      .header-container {
-        padding: 12px 16px;
-      }
-
-      .hero {
-        padding: 100px 16px 60px;
-      }
-
-      .hero-actions {
-        flex-direction: column;
-        align-items: center;
-      }
-
-      .btn-primary,
-      .btn-secondary {
-        width: 100%;
-        max-width: 280px;
-        text-align: center;
-      }
-
-      .services,
-      .projects {
-        padding: 60px 16px;
-      }
-
-      .services-grid {
-        grid-template-columns: 1fr;
-      }
-
-      .footer-main {
-        flex-direction: column;
-      }
-
-      .footer-links {
-        flex-direction: column;
-        gap: 32px;
-      }
-
-      .footer-bottom {
-        flex-direction: column;
-        text-align: center;
-      }
-    }
-
-    /* Why Us Section */
-    .why-us {
-      padding: 100px 24px;
-      position: relative;
-    }
-
-    .stats-row {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 24px;
-      max-width: 1200px;
-      margin: 0 auto;
-    }
-
-    .stat-card {
-      background: var(--bg-card);
-      border: 1px solid var(--border-subtle);
-      border-radius: 20px;
-      padding: 36px 28px;
-      transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-      position: relative;
-      overflow: hidden;
-    }
-
-    .stat-card::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(135deg, rgba(59, 130, 246, 0.08) 0%, transparent 60%);
+    .line {
+      max-width: 22ch;
       opacity: 0;
-      transition: opacity 0.4s ease;
+      transform: translateY(18px);
+      will-change: opacity, transform;
     }
 
-    .stat-card:hover {
-      transform: translateY(-6px);
-      border-color: var(--accent-blue);
-      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4), 0 0 30px var(--accent-glow);
+    .chapter[data-align="center"] .line {
+      max-width: none;
     }
 
-    .stat-card:hover::before {
+    .line .observation {
+      font-size: clamp(28px, 5.2vw, 64px);
+      font-weight: 500;
+      line-height: 1.05;
+      letter-spacing: -0.02em;
+      color: var(--ink);
+    }
+
+    .line .annotation {
+      display: inline-block;
+      margin-top: 22px;
+      font-size: clamp(11px, 1.1vw, 13px);
+      color: var(--ink-dim);
+      letter-spacing: 0.18em;
+    }
+
+    .line .annotation b {
+      color: var(--accent);
+      font-weight: 500;
+      transition: color 1.2s ease;
+    }
+
+    /* ============ Final / STATE frame ============ */
+    #state .line {
+      position: relative;
+    }
+
+    #state .wordmark {
+      font-size: clamp(36px, 9vw, 132px);
+      font-weight: 600;
+      letter-spacing: -0.03em;
+      line-height: 1;
+      color: var(--ink);
+    }
+
+    #state .wordmark em {
+      font-style: normal;
+      color: var(--accent);
+      transition: color 1.2s ease;
+    }
+
+    #state .resolve-link {
+      pointer-events: auto;
+      position: absolute;
+      left: 50%;
+      bottom: clamp(-86px, -7vw, -64px);
+      transform: translateX(-50%);
+      white-space: nowrap;
+      font-size: 13px;
+      color: var(--ink-dim);
+      text-decoration: none;
+      border-bottom: 1px solid var(--hud-line);
+      padding-bottom: 3px;
+      transition: color 0.5s ease, border-color 0.5s ease;
+    }
+
+    #state .resolve-link:hover {
+      color: var(--ink);
+      border-color: var(--accent);
+    }
+
+    /* ============ Persistent HUD ============ */
+    .hud {
+      position: fixed;
+      inset: 0;
+      z-index: 5;
+      pointer-events: none;
+      color: var(--ink-dim);
+      font-family: 'JetBrains Mono', ui-monospace, monospace;
+      font-size: 11px;
+      letter-spacing: 0.12em;
+    }
+
+    .hud .tag {
+      color: var(--ink-dim);
+    }
+
+    .hud .tag b {
+      color: var(--ink);
+      font-weight: 500;
+    }
+
+    /* registration / crop marks */
+    .reg {
+      position: fixed;
+      inset: 0;
+      z-index: 4;
+      pointer-events: none;
+    }
+
+    .reg .crop {
+      position: absolute;
+      width: 22px;
+      height: 22px;
+    }
+
+    .reg .crop::before,
+    .reg .crop::after {
+      content: '';
+      position: absolute;
+      background: var(--hud-line);
+    }
+
+    /* vertical arm */
+    .reg .crop::before {
+      width: 1px;
+      height: 22px;
+    }
+
+    /* horizontal arm */
+    .reg .crop::after {
+      height: 1px;
+      width: 22px;
+    }
+
+    .reg .crop-tl {
+      top: clamp(16px, 2.6vw, 30px);
+      left: clamp(16px, 2.6vw, 30px);
+    }
+
+    .reg .crop-tr {
+      top: clamp(16px, 2.6vw, 30px);
+      right: clamp(16px, 2.6vw, 30px);
+    }
+
+    .reg .crop-tr::before {
+      right: 0;
+    }
+
+    .reg .crop-tr::after {
+      right: 0;
+    }
+
+    .reg .crop-bl {
+      bottom: clamp(16px, 2.6vw, 30px);
+      left: clamp(16px, 2.6vw, 30px);
+    }
+
+    .reg .crop-bl::before {
+      bottom: 0;
+    }
+
+    .reg .crop-bl::after {
+      bottom: 0;
+    }
+
+    .reg .crop-br {
+      bottom: clamp(16px, 2.6vw, 30px);
+      right: clamp(16px, 2.6vw, 30px);
+    }
+
+    .reg .crop-br::before {
+      bottom: 0;
+      right: 0;
+    }
+
+    .reg .crop-br::after {
+      bottom: 0;
+      right: 0;
+    }
+
+    /* center crosshair + orientation tick */
+    .reg .cross {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 0;
+      height: 0;
+    }
+
+    .reg .cross-h,
+    .reg .cross-v {
+      position: absolute;
+      background: var(--hud-line);
+    }
+
+    .reg .cross-h {
+      width: 28px;
+      height: 1px;
+      left: -14px;
+      top: 0;
+    }
+
+    .reg .cross-v {
+      width: 1px;
+      height: 28px;
+      left: 0;
+      top: -14px;
+    }
+
+    .reg .cross-ring {
+      position: absolute;
+      width: 54px;
+      height: 54px;
+      left: -27px;
+      top: -27px;
+      border: 1px solid var(--hud-line);
+      border-radius: 50%;
+    }
+
+    .reg .cross-tick {
+      position: absolute;
+      width: 1px;
+      height: 12px;
+      left: 0;
+      top: -39px;
+      background: var(--hud-line-strong);
+    }
+
+    .reg .cross-n {
+      position: absolute;
+      left: 8px;
+      top: -44px;
+      color: var(--ink-faint);
+      font-size: 9px;
+      letter-spacing: 0.1em;
+    }
+
+    /* top-left brackets */
+    .hud-tl {
+      position: absolute;
+      top: clamp(18px, 3vw, 34px);
+      left: clamp(18px, 3vw, 34px);
+      line-height: 1.9;
+    }
+
+    .hud-tl .neg {
+      color: var(--accent);
+      transition: color 1.2s ease;
+    }
+
+    /* top-right chapter index */
+    .hud-tr {
+      position: absolute;
+      top: clamp(18px, 3vw, 34px);
+      right: clamp(18px, 3vw, 34px);
+      text-align: right;
+      line-height: 2.1;
+    }
+
+    .hud-tr .idx {
+      display: block;
+      color: var(--ink-faint);
+      transition: color 0.6s ease, letter-spacing 0.6s ease;
+    }
+
+    .hud-tr .idx .bullet {
+      opacity: 0;
+      margin-right: 8px;
+      color: var(--accent);
+      transition: opacity 0.6s ease;
+    }
+
+    .hud-tr .idx.active {
+      color: var(--ink);
+      letter-spacing: 0.22em;
+    }
+
+    .hud-tr .idx.active .bullet {
       opacity: 1;
     }
 
-    .stat-number {
-      font-family: 'Space Grotesk', sans-serif;
-      font-size: 42px;
-      font-weight: 700;
-      background: linear-gradient(135deg, var(--accent-blue-light), var(--accent-blue));
-      -webkit-background-clip: text;
-      background-clip: text;
-      color: transparent;
-      line-height: 1;
-      margin-bottom: 8px;
+    .hud-tr .idx.past {
+      color: var(--ink-dim);
+    }
+
+    /* progress rail under chapter index */
+    .hud-tr .rail {
+      margin-top: 14px;
+      margin-left: auto;
+      width: 120px;
+      height: 1px;
+      background: var(--hud-line);
       position: relative;
-      z-index: 1;
     }
 
-    .stat-label {
-      font-size: 13px;
-      font-weight: 600;
-      color: var(--text-primary);
-      text-transform: uppercase;
-      letter-spacing: 1px;
-      margin-bottom: 12px;
-      position: relative;
-      z-index: 1;
+    .hud-tr .rail .fill {
+      position: absolute;
+      left: 0;
+      top: 0;
+      height: 100%;
+      width: 0%;
+      background: var(--accent);
+      transition: width 0.1s linear, background 1.2s ease;
     }
 
-    .stat-desc {
-      color: var(--text-secondary);
-      font-size: 14px;
-      line-height: 1.7;
-      position: relative;
-      z-index: 1;
+    .hud-tr .pct {
+      display: block;
+      margin-top: 8px;
+      color: var(--ink-faint);
     }
 
-    /* Process Section */
-    .process {
-      padding: 100px 24px;
-      background: linear-gradient(180deg, var(--bg-primary) 0%, var(--bg-secondary) 100%);
+    /* bottom-left section counter */
+    .hud-bl {
+      position: absolute;
+      bottom: clamp(18px, 3vw, 34px);
+      left: clamp(18px, 3vw, 34px);
     }
 
-    .process-steps {
-      max-width: 800px;
-      margin: 0 auto;
+    .hud-bl .sec {
+      color: var(--ink);
+      font-size: 12px;
+      letter-spacing: 0.16em;
+    }
+
+    .hud-bl .sec .accent {
+      color: var(--accent);
+      transition: color 1.2s ease;
+    }
+
+    .hud-bl .coords {
+      margin-top: 6px;
+      color: var(--ink-faint);
+    }
+
+    /* bottom-right readout */
+    .hud-br {
+      position: absolute;
+      bottom: clamp(18px, 3vw, 34px);
+      right: clamp(18px, 3vw, 34px);
+      text-align: right;
+      color: var(--ink-faint);
+      line-height: 1.9;
+    }
+
+    .hud-br .live {
+      color: var(--ink-dim);
+    }
+
+    /* loading state */
+    .boot {
+      position: fixed;
+      inset: 0;
+      z-index: 10;
       display: flex;
-      flex-direction: column;
-      gap: 0;
+      align-items: center;
+      justify-content: center;
+      background: var(--bg);
+      color: var(--ink-dim);
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 11px;
+      letter-spacing: 0.3em;
+      transition: opacity 0.8s ease;
     }
 
-    .process-step {
-      display: flex;
-      gap: 32px;
-      align-items: flex-start;
-      padding: 32px;
-      background: var(--bg-card);
-      border: 1px solid var(--border-subtle);
-      border-radius: 20px;
-      transition: all 0.4s ease;
-      position: relative;
+    .boot.gone {
+      opacity: 0;
+      pointer-events: none;
     }
 
-    .process-step:hover {
-      border-color: var(--accent-blue);
-      box-shadow: 0 0 30px var(--accent-glow);
-      transform: translateX(6px);
+    /* scroll hint, fades after first scroll */
+    .scroll-hint {
+      position: fixed;
+      bottom: clamp(18px, 3vw, 34px);
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 5;
+      color: var(--ink-faint);
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 10px;
+      letter-spacing: 0.4em;
+      pointer-events: none;
+      transition: opacity 0.6s ease;
     }
 
-    .process-connector {
-      width: 2px;
-      height: 24px;
-      background: linear-gradient(to bottom, var(--accent-blue), transparent);
-      margin-left: 56px;
-      opacity: 0.4;
-    }
-
-    .step-number {
-      font-family: 'Space Grotesk', sans-serif;
-      font-size: 36px;
-      font-weight: 700;
-      background: linear-gradient(135deg, var(--accent-blue-light), var(--accent-blue));
-      -webkit-background-clip: text;
-      background-clip: text;
-      color: transparent;
-      line-height: 1;
-      min-width: 56px;
-      flex-shrink: 0;
-    }
-
-    .step-content h3 {
-      font-family: 'Space Grotesk', sans-serif;
-      font-size: 20px;
-      font-weight: 700;
-      margin-bottom: 8px;
-    }
-
-    .step-content p {
-      color: var(--text-secondary);
-      font-size: 15px;
-      line-height: 1.7;
-    }
-
-    @media (max-width: 768px) {
-      .why-us,
-      .process {
-        padding: 60px 16px;
+    @media (max-width: 720px) {
+      .hud-br {
+        display: none;
       }
 
-      .stats-row {
-        grid-template-columns: 1fr;
+      .hud-tr .rail {
+        width: 78px;
       }
 
-      .process-step {
-        flex-direction: column;
-        gap: 16px;
-      }
-
-      .process-connector {
-        margin-left: 32px;
-        height: 16px;
+      .line .observation {
+        font-size: clamp(26px, 8vw, 40px);
       }
     }
 
-    /* Focus styles for accessibility */
-    a:focus-visible,
-    button:focus-visible {
-      outline: 2px solid var(--accent-blue);
-      outline-offset: 2px;
-    }
-
-    /* Reduced motion */
     @media (prefers-reduced-motion: reduce) {
-
-      *,
-      *::before,
-      *::after {
-        animation-duration: 0.01ms !important;
-        animation-iteration-count: 1 !important;
-        transition-duration: 0.01ms !important;
+      .scroll-hint {
+        display: none;
       }
     }
   </style>
 </head>
 
 <body>
-  <!-- Animated Background -->
-  <div class="animated-bg">
-    <div class="gradient-orb orb-1"></div>
-    <div class="gradient-orb orb-2"></div>
-    <div class="gradient-orb orb-3"></div>
+  <!-- WebGL point-cloud canvas -->
+  <canvas id="gl"></canvas>
+  <div class="vignette"></div>
+  <div class="grain"></div>
+
+  <!-- Registration / crop marks (blueprint framing) -->
+  <div class="reg" aria-hidden="true">
+    <span class="crop crop-tl"></span>
+    <span class="crop crop-tr"></span>
+    <span class="crop crop-bl"></span>
+    <span class="crop crop-br"></span>
+    <div class="cross">
+      <span class="cross-h"></span>
+      <span class="cross-v"></span>
+      <span class="cross-ring"></span>
+      <span class="cross-tick"></span>
+      <span class="cross-n mono">N</span>
+    </div>
   </div>
 
-  <!-- Particles -->
-  <div class="particles">
-    <div class="particle"></div>
-    <div class="particle"></div>
-    <div class="particle"></div>
-    <div class="particle"></div>
-    <div class="particle"></div>
-    <div class="particle"></div>
-    <div class="particle"></div>
-    <div class="particle"></div>
+  <!-- Scroll content -->
+  <main>
+    <section class="chapter" data-chapter="0" data-align="left">
+      <div class="line">
+        <div class="observation">Every system tends toward disorder.</div>
+        <span class="annotation mono">[ ENTROPY <b>&rarr;</b> ]</span>
+      </div>
+    </section>
+
+    <section class="chapter" data-chapter="1" data-align="right">
+      <div class="line">
+        <div class="observation">A field is just structure, briefly held.</div>
+        <span class="annotation mono">[ <b><span class="npoints">N</span></b> points ]</span>
+      </div>
+    </section>
+
+    <section class="chapter" data-chapter="2" data-align="left">
+      <div class="line">
+        <div class="observation">Order is a temporary arrangement.</div>
+        <span class="annotation mono">[ &Delta; <b>&asymp; 0</b> ]</span>
+      </div>
+    </section>
+
+    <section class="chapter" data-chapter="3" data-align="right">
+      <div class="line">
+        <div class="observation">Nothing stays resolved.</div>
+        <span class="annotation mono">[ drift <b>&times; t</b> ]</span>
+      </div>
+    </section>
+
+    <section class="chapter" data-chapter="4" data-align="left">
+      <div class="line">
+        <div class="observation">Something has to push back.</div>
+        <span class="annotation mono">[ <b>&minus;&nabla;S</b> ]</span>
+      </div>
+    </section>
+
+    <section class="chapter" id="state" data-chapter="5" data-align="center">
+      <div class="line">
+        <div class="wordmark">protolab<em>.tech</em></div>
+        <a class="resolve-link mono" href="service-appointments/">/service-appointments</a>
+      </div>
+    </section>
+  </main>
+
+  <!-- Persistent HUD -->
+  <div class="hud" aria-hidden="true">
+    <div class="hud-tl mono">
+      <div class="tag">( <b>PROTOLAB.TECH</b> )</div>
+      <div class="tag">[ <span class="neg">NEGENTROPY</span> ]</div>
+    </div>
+
+    <div class="hud-tr mono">
+      <span class="idx" data-i="0"><span class="bullet">&middot;</span>NOISE</span>
+      <span class="idx" data-i="1"><span class="bullet">&middot;</span>FIELD</span>
+      <span class="idx" data-i="2"><span class="bullet">&middot;</span>ORDER</span>
+      <span class="idx" data-i="3"><span class="bullet">&middot;</span>DRIFT</span>
+      <span class="idx" data-i="4"><span class="bullet">&middot;</span>RESOLVE</span>
+      <span class="idx" data-i="5"><span class="bullet">&middot;</span>STATE</span>
+      <div class="rail">
+        <div class="fill"></div>
+      </div>
+      <span class="pct">0.000</span>
+    </div>
+
+    <div class="hud-bl mono">
+      <div class="sec">SEC.<span class="secnum">001</span> &mdash; <span class="accent secname">NOISE</span></div>
+      <div class="coords">x <span class="cx">+0.00</span> &nbsp; y <span class="cy">+0.00</span></div>
+    </div>
+
+    <div class="hud-br mono">
+      <div class="live">SIM <span class="simstate">RUNNING</span></div>
+      <div>dt <span class="fps">0.000</span></div>
+      <div>N <span class="ncount">0</span></div>
+    </div>
   </div>
 
-  <!-- Header -->
-  <header id="header">
-    <div class="header-container">
-      <a href="/" class="logo">protolab<span>.tech</span></a>
-      <nav>
-        <ul>
-          <li><a href="#services">Services</a></li>
-          <li><a href="#why-us">Why Us</a></li>
-          <li><a href="#process">Process</a></li>
-        </ul>
-      </nav>
-      <a href="service-appointments/" class="cta-btn">Book Appointment</a>
-    </div>
-  </header>
+  <div class="scroll-hint mono">SCROLL</div>
 
-  <!-- Hero Section -->
-  <section class="hero">
-    <div class="hero-content">
-      <div class="hero-badge">
-        <span class="dot"></span>
-        Available for new projects
-      </div>
-      <h1>Transform Ideas into<br><span class="gradient-text">Reality</span></h1>
-      <p>Professional prototyping services including 3D printing, laser cutting, and CNC engraving. We bring your
-        creative visions to life with precision and passion.</p>
-      <div class="hero-actions">
-        <a href="service-appointments/" class="btn-primary">Start Your Project</a>
-        <a href="#services" class="btn-secondary">Explore Services</a>
-      </div>
-    </div>
-    <div class="scroll-indicator">
-      <div class="mouse"></div>
-      <span>Scroll to explore</span>
-    </div>
-  </section>
+  <div class="boot mono"><span>INITIALIZING FIELD</span></div>
 
-  <!-- Services Section -->
-  <section class="services" id="services">
-    <div class="section-header">
-      <p class="section-label">Our Services</p>
-      <h2 class="section-title">Precision Prototyping</h2>
-      <p class="section-desc">From concept to creation, we offer cutting-edge manufacturing services tailored to your
-        needs.</p>
-    </div>
-    <div class="services-grid">
-      <div class="service-card">
-        <div class="service-icon">🖨️</div>
-        <h3>3D Printing</h3>
-        <p>High-quality additive manufacturing with various materials including PLA, ABS, PETG, and resin for detailed
-          prototypes and functional parts.</p>
-      </div>
-      <div class="service-card">
-        <div class="service-icon">✂️</div>
-        <h3>Laser Cutting</h3>
-        <p>Precise laser cutting and engraving on wood, acrylic, leather, and more. Perfect for intricate designs and
-          custom signage.</p>
-      </div>
-      <div class="service-card">
-        <div class="service-icon">⚙️</div>
-        <h3>CNC Engraving</h3>
-        <p>Computer-controlled precision engraving for metals, plastics, and wood. Ideal for industrial parts and
-          personalized items.</p>
-      </div>
-      <div class="service-card">
-        <div class="service-icon">🤖</div>
-        <h3>Industrial Automation</h3>
-        <p>Custom software solutions for industrial automation, process optimization, and smart manufacturing systems.
-        </p>
-      </div>
-      <div class="service-card">
-        <div class="service-icon">🏠</div>
-        <h3>Home Automation</h3>
-        <p>Smart home solutions including IoT integration, automated controls, and custom home management systems.</p>
-      </div>
-      <div class="service-card">
-        <div class="service-icon">💻</div>
-        <h3>Web & Software</h3>
-        <p>Website creation, custom software development, and tailored digital solutions for your unique business needs.
-        </p>
-      </div>
-    </div>
-  </section>
+  <!-- smooth scroll + scroll-driven state (classic scripts expose globals) -->
+  <script src="https://cdn.jsdelivr.net/npm/lenis@1.1.14/dist/lenis.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/ScrollTrigger.min.js"></script>
 
-  <!-- Why Us Section -->
-  <section class="why-us" id="why-us">
-    <div class="section-header">
-      <p class="section-label">Why Protolab</p>
-      <h2 class="section-title">Built for Results</h2>
-      <p class="section-desc">We combine technical depth with fast execution — so your ideas move from sketch to shipment without friction.</p>
-    </div>
-    <div class="stats-row">
-      <div class="stat-card">
-        <div class="stat-number">48h</div>
-        <div class="stat-label">Typical turnaround</div>
-        <div class="stat-desc">From approved design to finished part, most orders ship within two business days.</div>
-      </div>
-      <div class="stat-card">
-        <div class="stat-number">0.1mm</div>
-        <div class="stat-label">Print precision</div>
-        <div class="stat-desc">Layer resolution down to 0.1 mm for parts that fit right the first time.</div>
-      </div>
-      <div class="stat-card">
-        <div class="stat-number">6+</div>
-        <div class="stat-label">Disciplines under one roof</div>
-        <div class="stat-desc">3D printing, laser cutting, CNC, automation, IoT, and software — no handoffs, no delays.</div>
-      </div>
-      <div class="stat-card">
-        <div class="stat-number">End-to-end</div>
-        <div class="stat-label">Full-stack prototyping</div>
-        <div class="stat-desc">Hardware and software together. We build the device and the system that runs it.</div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Process Section -->
-  <section class="process" id="process">
-    <div class="section-header">
-      <p class="section-label">How We Work</p>
-      <h2 class="section-title">From Idea to Reality</h2>
-      <p class="section-desc">A clear, collaborative process designed to move fast without cutting corners.</p>
-    </div>
-    <div class="process-steps">
-      <div class="process-step">
-        <div class="step-number">01</div>
-        <div class="step-content">
-          <h3>Brief &amp; Scope</h3>
-          <p>Share your idea — a sketch, a reference, or just a problem to solve. We define scope, materials, and timeline together before anything starts.</p>
-        </div>
-      </div>
-      <div class="process-connector"></div>
-      <div class="process-step">
-        <div class="step-number">02</div>
-        <div class="step-content">
-          <h3>Design &amp; Validate</h3>
-          <p>We model, simulate, or prototype digitally first. You review and approve before a single machine runs.</p>
-        </div>
-      </div>
-      <div class="process-connector"></div>
-      <div class="process-step">
-        <div class="step-number">03</div>
-        <div class="step-content">
-          <h3>Manufacture</h3>
-          <p>Production runs on our in-house machines — 3D printers, laser cutters, CNC — with full quality checks at each stage.</p>
-        </div>
-      </div>
-      <div class="process-connector"></div>
-      <div class="process-step">
-        <div class="step-number">04</div>
-        <div class="step-content">
-          <h3>Deliver &amp; Iterate</h3>
-          <p>Parts ship fast. If revision is needed, we loop back immediately — no restarts, no extra onboarding.</p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Footer -->
-  <footer>
-    <div class="footer-container">
-      <div class="footer-main">
-        <div class="footer-brand">
-          <a href="/" class="logo">protolab<span>.tech</span></a>
-          <p>Transforming creative ideas into tangible reality through precision manufacturing and innovative
-            prototyping solutions.</p>
-        </div>
-        <div class="footer-links">
-          <div class="footer-col">
-            <h4>Services</h4>
-            <ul>
-              <li><a href="#services">3D Printing</a></li>
-              <li><a href="#services">Laser Cutting</a></li>
-              <li><a href="#services">CNC Engraving</a></li>
-            </ul>
-          </div>
-          <div class="footer-col">
-            <h4>Quick Links</h4>
-            <ul>
-              <li><a href="service-appointments/">Book Appointment</a></li>
-              <li><a href="#why-us">Why Us</a></li>
-              <li><a href="policy.html">Privacy Policy</a></li>
-            </ul>
-          </div>
-        </div>
-      </div>
-      <div class="footer-bottom">
-        <p>&copy; 2026 protolab.tech. All rights reserved.</p>
-        <div class="social-links">
-          <a href="https://github.com/protolab-tech" aria-label="GitHub">
-            <svg width="20" height="20" fill="currentColor" viewBox="0 0 24 24">
-              <path
-                d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
-            </svg>
-          </a>
-        </div>
-      </div>
-    </div>
-  </footer>
-
-  <script>
-    // Header scroll effect
-    const header = document.getElementById('header');
-    window.addEventListener('scroll', () => {
-      if (window.scrollY > 50) {
-        header.classList.add('scrolled');
-      } else {
-        header.classList.remove('scrolled');
-      }
-    });
-
-    // Smooth scroll for anchor links
-    document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-      anchor.addEventListener('click', function (e) {
-        e.preventDefault();
-        const target = document.querySelector(this.getAttribute('href'));
-        if (target) {
-          target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
-      });
-    });
-
-    // Intersection Observer for scroll animations
-    const observerOptions = {
-      threshold: 0.1,
-      rootMargin: '0px 0px -50px 0px'
-    };
-
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          entry.target.style.opacity = '1';
-          entry.target.style.transform = 'translateY(0)';
-        }
-      });
-    }, observerOptions);
-
-    // Observe service and project cards
-    document.querySelectorAll('.service-card, .project-card').forEach((card, i) => {
-      card.style.opacity = '0';
-      card.style.transform = 'translateY(30px)';
-      card.style.transition = `opacity 0.6s ease ${i * 0.1}s, transform 0.6s ease ${i * 0.1}s`;
-      observer.observe(card);
-    });
-  </script>
+  <script type="module" src="assets/js/negentropy.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this is

Replaces the marketing homepage with a single-page, scroll-driven generative experience. Cold, minimal, immersive, mathy — the company as an abstract solving-force, inferred from atmosphere rather than claims. No value props, CTAs, feature lists, or warmth.

## Core motif

ONE reusable GLSL point-cloud, parameterized by a single scroll-progress uniform, runs as one continuous simulation that passes through six states (never separate static slides):

`NOISE → FIELD → ORDER → DRIFT → RESOLVE → STATE`

It scatters into noise, holds a field, collapses into an ordered lattice, drifts, re-converges into a sphere that "pushes back," and finally resolves precisely onto the `protolab.tech` wordmark.

| NOISE (with early link) | DRIFT (sharpened) | FIELD |
|---|---|---|
| [sharp_0.png](https://cursor.com/agents/bc-d312e7fc-53c2-4eed-b84e-e2a94f9fda96/artifacts?path=%2Ftmp%2Fsharp_0.png) | [sharp_mid.png](https://cursor.com/agents/bc-d312e7fc-53c2-4eed-b84e-e2a94f9fda96/artifacts?path=%2Ftmp%2Fsharp_mid.png) | [shot_20.png](https://cursor.com/agents/bc-d312e7fc-53c2-4eed-b84e-e2a94f9fda96/artifacts?path=%2Ftmp%2Fshot_20.png) |

| RESOLVE | STATE (wordmark) | Mobile |
|---|---|---|
| [shot_80.png](https://cursor.com/agents/bc-d312e7fc-53c2-4eed-b84e-e2a94f9fda96/artifacts?path=%2Ftmp%2Fshot_80.png) | [shot_final.png](https://cursor.com/agents/bc-d312e7fc-53c2-4eed-b84e-e2a94f9fda96/artifacts?path=%2Ftmp%2Fshot_final.png) | [m_100.png](https://cursor.com/agents/bc-d312e7fc-53c2-4eed-b84e-e2a94f9fda96/artifacts?path=%2Ftmp%2Fm_100.png) |

## Persistent HUD (fixed across scroll)

- Top-left bracket tags: `( PROTOLAB.TECH )` / `[ NEGENTROPY ]`
- Top-right chapter index doubling as scroll progress: `NOISE · FIELD · ORDER · DRIFT · RESOLVE · STATE`
- Corner crop / registration marks + a center orientation tick (`N`) for blueprint framing
- Mono section counter: `SEC.001 — NOISE`, `SEC.002 — FIELD`, … plus live instrument readouts (progress, point count, dt, pointer coords)

## Interaction

- Clicking any text cluster smoothly advances to the next section (Lenis-driven; native smooth scroll as fallback), so the full sequence is reachable without manual scrolling. The final frame holds.
- The bare `/service-appointments` link appears on the first text cluster **and** in the final frame — reachable immediately, without scrolling the whole page.

## Rendering quality

- Full device pixel ratio (capped at 2) on all devices + MSAA antialiasing.
- Point sprites use a tight, hard-edged core with a faint halo instead of a soft gaussian falloff — crisp, defined particles rather than blur.

## Design rules honored

- Near-black canvas (`#050507`); ONE muted accent that shifts per chapter (steel → cyan → white)
- Space Grotesk display type, JetBrains Mono for all data annotations; generous negative space
- Copy is sparse, declarative, ambient (observations, no verbs aimed at the visitor)
- Final frame: cloud resolves into the wordmark and holds; bare, unlabeled links only (no button styling, no "begin"/"contact us")
- Mobile: HUD + counter kept, particle count dropped (52k → 13k), single accent locked, field scaled to fit, morph preserved

## Stack note

The site is a static GitHub Pages page with no build step, so I kept that stack: `three` is loaded as an ESM module via import map, and Lenis + GSAP ScrollTrigger via CDN. R3F/JSX would require introducing a bundler to a no-build static site, so the point-cloud is implemented with three's raw GLSL `ShaderMaterial` (which is exactly what R3F wraps) to preserve the existing deployment model. Chapter/morph state is read from live geometry each frame for robustness across native scroll, Lenis, and reduced-motion.

## Testing

Verified headlessly (Chrome + WebGL) at desktop and mobile viewports and with `prefers-reduced-motion`:
- WebGL context, three, Lenis, gsap, ScrollTrigger all load; boot overlay clears; no console/page errors.
- All six states render and the HUD chapter index, section counter, and accent track scroll correctly.
- Click-to-advance steps through NOISE → FIELD → ORDER → DRIFT correctly on desktop and mobile (tap).
- The early `/service-appointments` link navigates and does not trigger the advance behavior.
- The cloud resolves cleanly onto the crisp wordmark; graceful static fallback if WebGL is unavailable.

## Files

- `index.html` — the experience (HUD, sparse sections, styling, import map, deps)
- `assets/js/negentropy.js` — engine + GLSL shaders + scroll/HUD/interaction wiring


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d312e7fc-53c2-4eed-b84e-e2a94f9fda96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d312e7fc-53c2-4eed-b84e-e2a94f9fda96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

