### PR TITLE
Sharpen particle render, click-to-advance sections, early service link

### DIFF
--- a/assets/js/negentropy.js
+++ b/assets/js/negentropy.js
@@ -268,8 +268,10 @@ varying float vGlow;
 void main(){
   vec2 uv = gl_PointCoord - 0.5;
   float d = length(uv);
-  float core = smoothstep(0.5, 0.0, d);
-  float alpha = core * vAlpha * uOpacity;
+  // tight, hard-edged core with a faint halo — crisp instead of blurry
+  float core = smoothstep(0.34, 0.16, d);
+  float halo = smoothstep(0.5, 0.24, d) * 0.22;
+  float alpha = (core + halo) * vAlpha * uOpacity;
   if (alpha < 0.003) discard;
   vec3 col = vColor + vGlow * 0.18;
   gl_FragColor = vec4(col, alpha);
@@ -284,7 +286,7 @@ function start() {
   try {
     renderer = new THREE.WebGLRenderer({
       canvas: dom.canvas,
-      antialias: false,
+      antialias: true,
       alpha: false,
       powerPreference: 'high-performance',
     });
@@ -293,7 +295,8 @@ function start() {
   }
   if (!renderer || !renderer.getContext()) return fallback();
 
-  const pixelRatio = Math.min(window.devicePixelRatio || 1, isMobile ? 2 : 1.75);
+  // full device pixel ratio (capped at 2) for a crisp render
+  const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
   renderer.setPixelRatio(pixelRatio);
   renderer.setSize(window.innerWidth, window.innerHeight);
   renderer.setClearColor(0x050507, 1);
@@ -346,7 +349,7 @@ function start() {
   const uniforms = {
     uTime: { value: 0 },
     uProgress: { value: 0 },
-    uSize: { value: isMobile ? 3.0 : 2.3 },
+    uSize: { value: isMobile ? 3.4 : 2.7 },
     uOpacity: { value: 0.92 },
     uPixelRatio: { value: pixelRatio },
     uAccent: { value: new THREE.Color(isMobile ? MOBILE_ACCENT : ACCENTS[0]) },
@@ -473,6 +476,22 @@ function start() {
     });
     if (window.ScrollTrigger) lenis.on('scroll', window.ScrollTrigger.update);
   }
+
+  // clicking a text cluster advances the sequence to the next section
+  function scrollToSection(k) {
+    const sec = dom.sections[k];
+    if (!sec) return;
+    const top = sec.getBoundingClientRect().top + window.scrollY;
+    if (lenis) lenis.scrollTo(top, { duration: 1.6 });
+    else window.scrollTo({ top, behavior: prefersReduced ? 'auto' : 'smooth' });
+  }
+  dom.lines.forEach((line, k) => {
+    if (k >= dom.sections.length - 1) return; // final frame holds
+    line.addEventListener('click', (e) => {
+      if (e.target.closest('a')) return; // let bare links navigate
+      scrollToSection(k + 1);
+    });
+  });
 
   // pointer parallax
   if (!isMobile) {

--- a/index.html
+++ b/index.html
@@ -145,6 +145,12 @@
       will-change: opacity, transform;
     }
 
+    /* text clusters advance the sequence on click */
+    .chapter:not(#state) .line {
+      pointer-events: auto;
+      cursor: pointer;
+    }
+
     .chapter[data-align="center"] .line {
       max-width: none;
     }
@@ -171,6 +177,29 @@
       transition: color 1.2s ease;
     }
 
+    /* bare, unlabeled link (shared by the early cluster and the final frame) */
+    .bare-link {
+      pointer-events: auto;
+      white-space: nowrap;
+      font-size: 13px;
+      color: var(--ink-dim);
+      text-decoration: none;
+      border-bottom: 1px solid var(--hud-line);
+      padding-bottom: 3px;
+      transition: color 0.5s ease, border-color 0.5s ease;
+    }
+
+    .bare-link:hover {
+      color: var(--ink);
+      border-color: var(--accent);
+    }
+
+    .line .early-link {
+      display: inline-block;
+      margin-top: 30px;
+      font-size: 12px;
+    }
+
     /* ============ Final / STATE frame ============ */
     #state .line {
       position: relative;
@@ -191,23 +220,10 @@
     }
 
     #state .resolve-link {
-      pointer-events: auto;
       position: absolute;
       left: 50%;
       bottom: clamp(-86px, -7vw, -64px);
       transform: translateX(-50%);
-      white-space: nowrap;
-      font-size: 13px;
-      color: var(--ink-dim);
-      text-decoration: none;
-      border-bottom: 1px solid var(--hud-line);
-      padding-bottom: 3px;
-      transition: color 0.5s ease, border-color 0.5s ease;
-    }
-
-    #state .resolve-link:hover {
-      color: var(--ink);
-      border-color: var(--accent);
     }
 
     /* ============ Persistent HUD ============ */
@@ -563,6 +579,8 @@
       <div class="line">
         <div class="observation">Every system tends toward disorder.</div>
         <span class="annotation mono">[ ENTROPY <b>&rarr;</b> ]</span>
+        <br>
+        <a class="bare-link early-link mono" href="service-appointments/">/service-appointments</a>
       </div>
     </section>
 
@@ -597,7 +615,7 @@
     <section class="chapter" id="state" data-chapter="5" data-align="center">
       <div class="line">
         <div class="wordmark">protolab<em>.tech</em></div>
-        <a class="resolve-link mono" href="service-appointments/">/service-appointments</a>
+        <a class="bare-link resolve-link mono" href="service-appointments/">/service-appointments</a>
       </div>
     </section>
   </main>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up refinements to the NEGENTROPY experience merged in #7.

## Changes

### Sharper render
- Full device pixel ratio (capped at 2) on all devices — previously 1.75 on desktop.
- MSAA antialiasing enabled on the WebGL context.
- Point sprites now use a tight, hard-edged core with a faint halo instead of a soft gaussian falloff; base point size compensated. Particles read as crisp, defined points rather than blur.

| NOISE (with early link) | DRIFT (sharpened) |
|---|---|
| [sharp_0.png](https://cursor.com/agents/bc-d312e7fc-53c2-4eed-b84e-e2a94f9fda96/artifacts?path=%2Ftmp%2Fsharp_0.png) | [sharp_mid.png](https://cursor.com/agents/bc-d312e7fc-53c2-4eed-b84e-e2a94f9fda96/artifacts?path=%2Ftmp%2Fsharp_mid.png) |

### Click-to-advance
- Clicking (or tapping) any text cluster smoothly scrolls to the next section — Lenis-driven when active, native smooth scroll otherwise — so the full sequence is reachable without manual scrolling. The final wordmark frame holds.

### Early service link
- The bare `/service-appointments` link now also appears on the first text cluster, so it is reachable without scrolling the whole page. The final-frame link remains. Shared `.bare-link` styling extracted for both; the cold, unlabeled register is preserved.

## Testing

Verified headlessly (Chrome + WebGL) at desktop and mobile viewports:
- Three consecutive clicks step NOISE → FIELD → ORDER → DRIFT with the HUD counter tracking each; tap works on mobile.
- The early link navigates to `service-appointments/` and does not trigger the advance behavior.
- No console or page errors on desktop, mobile, or reduced-motion runs.

## Files
- `index.html` — clickable cluster styling, shared bare-link style, early link markup
- `assets/js/negentropy.js` — pixel ratio / antialias / fragment falloff, click-to-advance wiring


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d312e7fc-53c2-4eed-b84e-e2a94f9fda96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d312e7fc-53c2-4eed-b84e-e2a94f9fda96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

